### PR TITLE
hide call bar on end call

### DIFF
--- a/src/components/common/CallDialog.js
+++ b/src/components/common/CallDialog.js
@@ -105,7 +105,7 @@ function CallDialog() {
   return (
     <>
       {currentAppointment &&
-      !currentAppointment.hasCallEnded &&
+      currentAppointment.hasAppointmentStarted &&
       location.pathname !== routes.teleHealth.path ? (
         <div>
           <Call

--- a/src/hooks/useTwilio.js
+++ b/src/hooks/useTwilio.js
@@ -81,6 +81,7 @@ const useTwilio = () => {
           ...currentAppointment,
           isCallInProgress: false,
           hasCallEnded: true,
+          hasAppointmentStarted: false,
         }),
       );
       dispatch(twilioActions.resetTwilio());


### PR DESCRIPTION
call was being initiated on login with initial apporach.
This apprach shows call bar on call initiation and hieds on call disconnect; doent initiae call upon login