### PR TITLE
fix position of call bar 

### DIFF
--- a/src/styles/_callWindow.scss
+++ b/src/styles/_callWindow.scss
@@ -1,8 +1,8 @@
 .call-window {
-  position: absolute;
+  position: fixed;
   bottom: 0.6rem;
   right: 25%;
-  left: 25%;
+  left: 20%;
   width: 60%;
   padding: 0.3rem 0.5rem;
   background-color: #dfdfdf;


### PR DESCRIPTION
`issue` 
 the call bar scrolls out of the window when the page is scrolled
 
 `fix`
the bar remains fixed at the bottom of the page

![call-bar-position](https://user-images.githubusercontent.com/54280935/120889152-86a04880-c61b-11eb-8cdf-591c67be175f.gif)
